### PR TITLE
set aptcachedir in pbuilderrc.erb

### DIFF
--- a/templates/pbuilderrc.erb
+++ b/templates/pbuilderrc.erb
@@ -43,7 +43,7 @@ USEDEVFS=no
 
 # specifying the distribution forces the distribution on "pbuilder update"
 #specify the cache for APT 
-APTCACHE="$PBUILDER_HOME/aptcache/"
+APTCACHE="<%= aptcachedir %>"
 APTCACHEHARDLINK="yes"
 REMOVEPACKAGES="lilo"
 


### PR DESCRIPTION
$aptcachedir wasn't be set in pbuilderrc.erb, so it ended up being created in /aptcache instead.
