### PR TITLE
use local $caller_module_name instead of top-scope

### DIFF
--- a/manifests/apt/preferences.pp
+++ b/manifests/apt/preferences.pp
@@ -19,7 +19,7 @@ define pbuilder::apt::preferences (
   # so we just concatenate
   $pin_release = ''
   $origin = ''
-  $explanation = "${::caller_module_name}: ${name}"
+  $explanation = "${caller_module_name}: ${name}"
   concat::fragment {$fname:
       ensure  => $ensure,
       target  => "/etc/pbuilder/${pbuilder_name}/apt/preferences",


### PR DESCRIPTION
I noticed the variable was empty when enabling strict_variables on puppet.
Using local instead of top-scope solves the problem. Which seems logic here.
