### PR TITLE
make cowbuilder class behave more like pbuilder

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,8 +31,8 @@
 #
 define pbuilder (
   $ensure       = 'present',
-  $release      = $lsbdistcodename,
-  $arch         = $architecture,
+  $release      = $facts['os']['distro']['codename'],
+  $arch         = $facts['os']['architecture'],
   $methodurl    = undef,
   $debbuildopts = '-b',
   $bindmounts   = undef,

--- a/spec/classes/pbuilder_common_spec.rb
+++ b/spec/classes/pbuilder_common_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe 'pbuilder::common' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { should compile.with_all_deps }
+
+      it { is_expected.to contain_package('pbuilder') }
+
+      it { is_expected.to contain_group('pbuilder') }
+    end
+  end
+end

--- a/spec/classes/pbuilder_cowbuilder_common_spec.rb
+++ b/spec/classes/pbuilder_cowbuilder_common_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe 'pbuilder::cowbuilder::common' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { should compile.with_all_deps }
+
+      it { is_expected.to contain_package('pbuilder') }
+      it { is_expected.to contain_package('cowbuilder') }
+
+      it { is_expected.to contain_group('pbuilder') }
+    end
+  end
+end

--- a/spec/defines/cowbuilder_spec.rb
+++ b/spec/defines/cowbuilder_spec.rb
@@ -1,13 +1,39 @@
 require 'spec_helper'
 
 describe 'pbuilder::cowbuilder' do
-  let (:title) { 'foo' }
+  let (:title) { 'moo' }
 
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
 
-      it { should compile.with_all_deps }
+      describe 'default parameters' do
+        it { should compile.with_all_deps }
+
+        it { is_expected.to contain_class('pbuilder::cowbuilder::common') }
+
+        it do
+          is_expected.to contain_file("/etc/pbuilder/moo/pbuilderrc").
+            with_content(/MIRRORSITE=""/).
+            with_content(/DISTRIBUTION="#{facts[:os]['distro']['codename']}"/).
+            with_content(/ARCH="#{facts[:os]['architecture']}"/).
+            with_content(/BASEPATH="\/var\/cache\/pbuilder\/base-moo\.cow"/).
+            without_content(/BASETGZ=/)
+        end
+      end
+
+      describe 'methodurl set' do
+        let (:params) do
+          {methodurl: 'http://ftp.debian.org/debian'}
+        end
+
+        it { should compile.with_all_deps }
+
+        it do
+          is_expected.to contain_file("/etc/pbuilder/moo/pbuilderrc").
+            with_content(/MIRRORSITE="http:\/\/ftp.debian.org\/debian"/)
+        end
+      end
     end
   end
 end

--- a/spec/defines/pbuilder_spec.rb
+++ b/spec/defines/pbuilder_spec.rb
@@ -7,7 +7,36 @@ describe 'pbuilder' do
     context "on #{os}" do
       let(:facts) { os_facts }
 
-      it { should compile.with_all_deps }
+      describe 'default parameters' do
+        it { should compile.with_all_deps }
+
+        it { is_expected.to contain_class('pbuilder::common') }
+
+        it do
+          is_expected.to contain_file("/etc/pbuilder/foo/pbuilderrc").
+            with_content(/MIRRORSITE=""/).
+            with_content(/DISTRIBUTION="#{facts[:os]['distro']['codename']}"/).
+            with_content(/ARCH="#{facts[:os]['architecture']}"/).
+            with_content(/BASETGZ="\/var\/chroot\/pbuilder\/base_foo\.tgz"/).
+            without_content(/BASEPATH=/)
+
+          is_expected.to contain_file("/usr/local/bin/pbuilder-foo").
+            with_content(/CONFIGFILE="\/etc\/pbuilder\/foo\/pbuilderrc"/)
+        end
+      end
+
+      describe 'methodurl set' do
+        let (:params) do
+          {methodurl: 'http://ftp.debian.org/debian'}
+        end
+
+        it { should compile.with_all_deps }
+
+        it do
+          is_expected.to contain_file("/etc/pbuilder/foo/pbuilderrc").
+            with_content(/MIRRORSITE="http:\/\/ftp.debian.org\/debian"/)
+        end
+      end
     end
   end
 end

--- a/templates/pbuilderrc.erb
+++ b/templates/pbuilderrc.erb
@@ -16,7 +16,11 @@ MIRRORSITE="<%= @methodurl %>"
 DISTRIBUTION="<%= @release %>"
 ARCH="<%= @arch %>"
 
+<% if @basetgz %>
 BASETGZ="<%= @basetgz %>"
+<% else %>
+BASEPATH="<%= @basepath %>"
+<% end %>
 BUILDPLACE="<%= @builddir %>"
 BUILDRESULT="<%= @resultdir %>"
 APTCACHE="<%= @aptcachedir %>"


### PR DESCRIPTION
I wanted to replace our use of `pbuilder` with `pbuilder::cowbuilder` and realized that their APIs don't exactly match (which is fine) and that the default deployment of `pbuilder::cowbuilder` is rather incomplete, as it deploys and empty config by default which results in a non-usable cowbuilder.

This is my attempt to fix it, ignoring API compatibility given it's still a `0.x` release.