### PR TITLE
Release 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,96 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+Each new release typically also includes the latest modulesync defaults.
+These should not affect the functionality of the module.
+
+## [v1.0.0](https://github.com/voxpupuli/puppet-pbuilder/tree/v1.0.0) (2022-09-16)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-pbuilder/compare/0.1.11...v1.0.0)
+
+**Breaking changes:**
+
+- make cowbuilder class behave more like pbuilder [\#13](https://github.com/voxpupuli/puppet-pbuilder/pull/13) ([evgeni](https://github.com/evgeni))
+
+**Implemented enhancements:**
+
+- Allow puppetlabs-concat 7.x [\#22](https://github.com/voxpupuli/puppet-pbuilder/pull/22) ([ekohl](https://github.com/ekohl))
+- Allow stdlib 8.0.0 [\#18](https://github.com/voxpupuli/puppet-pbuilder/pull/18) ([smortex](https://github.com/smortex))
+- Document the module using puppet-strings tags [\#17](https://github.com/voxpupuli/puppet-pbuilder/pull/17) ([ekohl](https://github.com/ekohl))
+- bump puppetlabs-\* upper limit [\#12](https://github.com/voxpupuli/puppet-pbuilder/pull/12) ([mmoll](https://github.com/mmoll))
+- bump puppetlabs-\* requirements [\#10](https://github.com/voxpupuli/puppet-pbuilder/pull/10) ([mmoll](https://github.com/mmoll))
+
+**Merged pull requests:**
+
+- fixtures.yml: Migrate to git URLs [\#20](https://github.com/voxpupuli/puppet-pbuilder/pull/20) ([bastelfreak](https://github.com/bastelfreak))
+- Set license to Apache 2.0 [\#16](https://github.com/voxpupuli/puppet-pbuilder/pull/16) ([ekohl](https://github.com/ekohl))
+- Migrate the module from Camptocamp to Vox Pupuli [\#15](https://github.com/voxpupuli/puppet-pbuilder/pull/15) ([ekohl](https://github.com/ekohl))
+- add Puppet 6 tests [\#11](https://github.com/voxpupuli/puppet-pbuilder/pull/11) ([mmoll](https://github.com/mmoll))
+
+## [0.1.11](https://github.com/voxpupuli/puppet-pbuilder/tree/0.1.11) (2017-06-27)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-pbuilder/compare/0.1.10...0.1.11)
+
+**Merged pull requests:**
+
+- allow newer puppetlabs-concat [\#9](https://github.com/voxpupuli/puppet-pbuilder/pull/9) ([mmoll](https://github.com/mmoll))
+- drop allow-unauthenticated from pbuilderrc [\#8](https://github.com/voxpupuli/puppet-pbuilder/pull/8) ([mmoll](https://github.com/mmoll))
+
+## [0.1.10](https://github.com/voxpupuli/puppet-pbuilder/tree/0.1.10) (2015-08-21)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-pbuilder/compare/0.1.9...0.1.10)
+
+## [0.1.9](https://github.com/voxpupuli/puppet-pbuilder/tree/0.1.9) (2015-06-26)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-pbuilder/compare/0.1.8...0.1.9)
+
+## [0.1.8](https://github.com/voxpupuli/puppet-pbuilder/tree/0.1.8) (2015-05-28)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-pbuilder/compare/0.1.7...0.1.8)
+
+## [0.1.7](https://github.com/voxpupuli/puppet-pbuilder/tree/0.1.7) (2015-05-26)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-pbuilder/compare/0.1.6...0.1.7)
+
+## [0.1.6](https://github.com/voxpupuli/puppet-pbuilder/tree/0.1.6) (2015-05-26)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-pbuilder/compare/0.1.5...0.1.6)
+
+## [0.1.5](https://github.com/voxpupuli/puppet-pbuilder/tree/0.1.5) (2015-05-26)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-pbuilder/compare/0.1.4...0.1.5)
+
+## [0.1.4](https://github.com/voxpupuli/puppet-pbuilder/tree/0.1.4) (2015-05-25)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-pbuilder/compare/0.1.3...0.1.4)
+
+## [0.1.3](https://github.com/voxpupuli/puppet-pbuilder/tree/0.1.3) (2015-05-13)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-pbuilder/compare/0.1.2...0.1.3)
+
+## [0.1.2](https://github.com/voxpupuli/puppet-pbuilder/tree/0.1.2) (2015-05-12)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-pbuilder/compare/0.1.1...0.1.2)
+
+## [0.1.1](https://github.com/voxpupuli/puppet-pbuilder/tree/0.1.1) (2015-04-27)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-pbuilder/compare/0.1.0...0.1.1)
+
+## [0.1.0](https://github.com/voxpupuli/puppet-pbuilder/tree/0.1.0) (2015-04-17)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-pbuilder/compare/22756500542b316d84b0267b9b893afd6bf285a5...0.1.0)
+
+**Closed issues:**
+
+- debootstrap and --allow-unauthenticated on Ubuntu 14.04 fails [\#5](https://github.com/voxpupuli/puppet-pbuilder/issues/5)
+
+**Merged pull requests:**
+
+- Make the pbuilderrc template replaceable [\#6](https://github.com/voxpupuli/puppet-pbuilder/pull/6) ([bdellegrazie](https://github.com/bdellegrazie))
+- Unit tests [\#4](https://github.com/voxpupuli/puppet-pbuilder/pull/4) ([mcanevet](https://github.com/mcanevet))
+- use local $caller\_module\_name instead of top-scope [\#3](https://github.com/voxpupuli/puppet-pbuilder/pull/3) ([saimonn](https://github.com/saimonn))
+- Resync with camptocamp modifications [\#2](https://github.com/voxpupuli/puppet-pbuilder/pull/2) ([mcanevet](https://github.com/mcanevet))
+
+
+
+\* *This Changelog was automatically generated by [github_changelog_generator](https://github.com/github-changelog-generator/github-changelog-generator)*

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppet-pbuilder",
-  "version": "0.1.11",
+  "version": "1.0.0",
   "author": "Vox Pupuli",
   "summary": "Puppet pbuilder module",
   "license": "Apache-2.0",


### PR DESCRIPTION
Given its age it deserves a real release. This is also the first VP release and moves forward on https://github.com/voxpupuli/puppet-pbuilder/issues/14.